### PR TITLE
V2

### DIFF
--- a/README.org
+++ b/README.org
@@ -10,11 +10,11 @@ go get github.com/Billes/go-logger-client
 *** Options
 #+BEGIN_EXAMPLE 
 type Options struct {
-	Host    string // vid tom sträng loggas allt lokalt
-	System  string // obligatorisk *
-	Token   string // obligatorisk om host finns
-	Local   bool   // Om den alltid ska skriva lokala loggar utöver den vanliga postningen
-	Timeout int		 // Hur länge den ska vänta på att requesten postas innan den avbryter och postar lokalt
+	Host    string
+	System  string
+	Token   string
+	Local   bool
+	Timeout int
 }
 #+END_EXAMPLE
 *** Init

--- a/README.org
+++ b/README.org
@@ -10,9 +10,11 @@ go get github.com/Billes/go-logger-client
 *** Options
 #+BEGIN_EXAMPLE 
 type Options struct {
-	Host   string // vid tom sträng loggas allt lokalt
-	System string // obligatorisk *
-	Token  string // obligatorisk om host finns
+	Host    string // vid tom sträng loggas allt lokalt
+	System  string // obligatorisk *
+	Token   string // obligatorisk om host finns
+	Local   bool   // Om den alltid ska skriva lokala loggar utöver den vanliga postningen
+	Timeout int		 // Hur länge den ska vänta på att requesten postas innan den avbryter och postar lokalt
 }
 #+END_EXAMPLE
 *** Init

--- a/logger.go
+++ b/logger.go
@@ -31,16 +31,12 @@ type logEntry struct {
 // Options is the config that is used for bootstrapping the logger.
 // Default is posting logs to remote server but omitting host will
 // write local logs instead.
-// Local flag decides if local logs should always be written in
-// addition to remote logs, defaults to false.
-// Timeout decides how long a request should be pending before
-// being cancelled and only writing local log.
 type Options struct {
-	Host    string `json:"host"`
-	System  string `json:"system"`
-	Token   string `json:"token"`
-	Local   bool   `json:"local"`
-	Timeout int    `json:"timeout"`
+	Host    string `json:"host"`    // When omitting, logs will be written locally
+	System  string `json:"system"`  // Required
+	Token   string `json:"token"`   // Required if Host is set
+	Local   bool   `json:"local"`   // Default false - If you want to force local logs in addition to the remote ones
+	Timeout int    `json:"timeout"` // Default 10 - How long communication with server is allowed to take before giving up and writing a local log
 }
 
 type logger struct {


### PR DESCRIPTION
* Har en ny flagga i konfigen om man alltid vill skriva lokala loggar utöver de externa
* Har en ny konfig vid namn timeout. Den avgör hur länge den väntar innan den avbryter en request. Default 10 sekunder
* Kör inte längre internt i en gorutin vid loggningar, vill man köra async kör man den själv som en gorutin
* Mer kommentarer
* Mer lokal loggning när saker vid loggningen kan gå fel